### PR TITLE
Update the name passed to convert.pl

### DIFF
--- a/doc/make_doc
+++ b/doc/make_doc
@@ -4,7 +4,7 @@ tex manual
 ../../../doc/manualindex manual
 tex manual
 mkdir -p ../htm
-../../../etc/convert.pl -c -i -u -n CARAT . ../htm
+../../../etc/convert.pl -c -i -u -n CARATINTERFACE . ../htm
 pdftex manual
 #dvips -o manual.ps manual
 #ps2pdf manual.ps manual.pdf


### PR DESCRIPTION
After the rename, running make_doc results in a lot of errors of this form:
```
Processed LAB files
1. Introduction ... introduction.tex
Warning: Chapter has no sections
2. Installation ... installation.tex
Warning: Chapter has no sections
3. Interface to CARAT ... carat.tex
Use of uninitialized value in string ne at ../../../etc/convert.pl line 606, <IN> line 52.
Use of uninitialized value in concatenation (.) or string at ../../../etc/convert.pl line 608, <IN> line 52.
Use of uninitialized value in concatenation (.) or string at ../../../etc/convert.pl line 608, <IN> line 52.
Section of "CaratTmpFile" (.) doesn't agree with the current section (3.2) at line 52 of carat.tex
... subsection will be unreachable
```
The problem is that the book name given in doc/manual.tex does not match the name passed to convert.pl (although convert.pl does a poor job of identifying the problem).