### PR TITLE
Include gap_all.h instead of src/compiled.h

### DIFF
--- a/src/setcaratdir.c
+++ b/src/setcaratdir.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include "src/compiled.h"
+
+#include "gap_all.h"
    
 Obj FuncSET_CARAT_DIR( Obj self, Obj str ) {
   setenv("CARAT_DIR", CSTR_STRING(str), 1);


### PR DESCRIPTION
This is helpful for GAP versions which are installed system wide
