### PR TITLE
CI: don't test against GAP 4.9 and 4.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,8 +27,6 @@ jobs:
           - master
           - stable-4.12
           - stable-4.11
-          - stable-4.10
-          - stable-4.9
         ABI: ['']
         include:
           - gap-branch: master


### PR DESCRIPTION
... as tjis package requires GAP >= 4.11
