### PR TITLE
Add missing CloseStream in CaratQClassCatalog

### DIFF
--- a/gap/methods.gi
+++ b/gap/methods.gi
@@ -554,6 +554,9 @@ InstallGlobalFunction( CaratQClassCatalog, function( grp , mode )
     # execute Carat program
     CaratCommand( "Q_catalog", args, resfile );
 
+    # remove temporary file
+    RemoveFile( grpfile );
+
     # parse the result file
     res := rec();
     input := InputTextFile( resfile );
@@ -587,6 +590,11 @@ InstallGlobalFunction( CaratQClassCatalog, function( grp , mode )
             SetSize( res.group, data.size );
         fi;
     fi;
+
+    CloseStream( input );
+
+    # remove temporary file
+    RemoveFile( resfile );
 
     return res;
 


### PR DESCRIPTION
Otherwise many invocations of `CaratQClassCatalog` lead to errno=24 (EMFILE, too many files open). `CaratQClassCatalog( grp, mode )` is also called from `ConjugatorQClass( G1, G2 )`.

The per-process limit on the number of open file descriptors has been reached (see the description of RLIMIT_NOFILE in getrlimit(2)).

My Error:

```
dyld[82534]: Library not loaded: '/usr/local/opt/gmp/lib/libgmp.10.dylib'
  Referenced from: '/Users/kiryph/Library/Preferences/GAP/pkg/CaratInterface/carat/bin/Q_catalog'
  Reason: tried: '/usr/local/opt/gmp/lib/libgmp.10.dylib' (open() failed with errno=24), '/usr/local/lib/libgmp.10.dylib' (open() failed with errno=24), '/usr/lib/libgmp.10.dylib' (no such file)
Error, Carat program Q_catalog failed with error code -1 at /Users/kiryph/Library/Preferences/GAP/pkg/CaratInterface/gap/carat.gi:629 called from
CaratCommand( "Q_catalog", args, resfile
 ); at /Users/kiryph/Library/Preferences/GAP/pkg/CaratInterface/gap/methods.gi:555 called from
CaratQClassCatalog( G1, 2 ) at /Users/kiryph/Library/Preferences/GAP/pkg/CaratInterface/gap/methods.gi:620 called from
ConjugatorQClass( P, pgroups@CrystSymbols[dim][q]
 )
```

I added also missing `RemoveFile` for temporary files.