### PR TITLE
read matrix fix

### DIFF
--- a/gap/carat.gi
+++ b/gap/carat.gi
@@ -171,6 +171,10 @@ BindGlobal( "CaratReadMatrix", function( input, str )
     local n, den, pos, m;
 
     n   := CaratNextNumber( str, 1 );
+    while n=fail do
+        str := CaratReadLine( input );
+        n   := CaratNextNumber( str, 1 );
+    od;
 
     # is matrix rational?
     pos := Position( str, '/' );

--- a/tst/carat.tst
+++ b/tst/carat.tst
@@ -122,3 +122,8 @@ gap> BravaisGroupsCrystalFamily( "4-2;1" );
   <matrix group of size 144 with 7 generators>, 
   <matrix group of size 288 with 4 generators>, 
   <matrix group of size 144 with 6 generators> ]
+
+gap> name := CaratTmpFile("pres");;
+gap> PrintTo(name, "\n2d1\n1 1\n");
+gap> CaratReadMatrixFile( name );
+[ [ 1, 0 ], [ 0, 1 ] ]


### PR DESCRIPTION
Resolves #37 

This sample solution simply reads new lines of the matrix file until the proper header is found. In fact, the header is not strictly checked, but it works for the files from CARAT.