### PR TITLE
etc/make_tar: ensure refs to GAP manual are relative

### DIFF
--- a/etc/make_tar
+++ b/etc/make_tar
@@ -6,8 +6,8 @@ PKGTAR=$DIR-2.3.10.tar
 # remove old archive
 rm -f $PKGTAR*
 
-# update documentaion
-(cd .. && gap -A -q --quitonbreak makedoc.g)
+# update documentation
+(cd .. && gap -A -q --quitonbreak -c 'Read("makedoc.g" : relativePath:="../../..");')
 
 # make the package archive
 mkdir -p $DIR


### PR DESCRIPTION
Thank you for the quick release of CaratInterface! Unfortunately it contains broken links to the GAP reference manual, from https://github.com/gap-system/PackageDistro/pull/1537 :
```
caratinterface: bad links in HTML documentation:
  doc/chap3.html:217: absolute path: /vol/opt/gap/gap-4.16.0/doc/ref/chap44.html#X7FB0138F79E8C5E7
  doc/chap3_mj.html:220: absolute path: /vol/opt/gap/gap-4.16.0/doc/ref/chap44_mj.html#X7FB0138F79E8C5E7
```

This PR contains a fix for the issue. Sorry for the inconvenience!

(BTW if you ever decide to host the tarballs and website for this here on GitHub, this kind of issue goes completely away, see https://github.com/gap-actions/release-pkg)